### PR TITLE
Address hanging on reading non-visible data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 release: release-linuxx64 release-macx64 release-winx64
 
 integration-test:
-	ginkgo run --label-filter="integration-test" -r ./..
+	ginkgo run -v --label-filter="integration-test" -r ./..
 
 release-linuxx64:
 	env GOOS=linux GOARCH=amd64 go build -o dist/fan-gopher-linuxx64-$(version) main.go

--- a/fans/rod/gopher.go
+++ b/fans/rod/gopher.go
@@ -27,7 +27,7 @@ func (rd *RodGopher) GetPostDetails(postID int64, creatorName string) (*model.Po
 		return nil, fmt.Errorf("unable to get page for post ID %d under creator '%s': %w", postID, creatorName, err)
 	}
 
-	actorNameAnchor, err := page.ElementX("//a[contains(@class, 'b-username')]")
+	actorNameAnchor, err := page.ElementX("//div[contains(@class, 'g-user-name')]")
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve username anchor: %w", err)
 	}
@@ -43,9 +43,14 @@ func (rd *RodGopher) GetPostDetails(postID int64, creatorName string) (*model.Po
 		actorImageURL = *actorImageSrc
 	}
 
-	videoDescriptionDiv, err := xpath(page, "//div[contains(@class, 'g-truncated-text')]")
+	videoDescriptionDivs, err := page.ElementsX("//div[contains(@class, 'b-post__text')]")
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve the video description div: %w", err)
+	}
+
+	var videoDescription string
+	if len(videoDescriptionDivs) > 0 {
+		videoDescription = videoDescriptionDivs[0].MustText()
 	}
 
 	return &model.Post{
@@ -56,7 +61,7 @@ func (rd *RodGopher) GetPostDetails(postID int64, creatorName string) (*model.Po
 			},
 		},
 		VideoDetails: &model.VideoDetails{
-			VideoDescription: videoDescriptionDiv.MustText(),
+			VideoDescription: videoDescription,
 		},
 	}, nil
 }


### PR DESCRIPTION
Some accounts do not disclose their posts to anonymous access, and, therefore, the post text is not visible. The gopher utility was hanging as a result.