### PR TITLE
Don't use Leakless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@
 fan-gopher
 dist/
 
-# Ignore VS Code artifacts
+# Ignore VS Code and OS artifacts
 .vscode
+.DS_Store
 
 # Ignore local runtime artifacts
 fan-gopher.log

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	fangopherrod "github.com/fansforyou/fan-gopher/fans/rod"
 	"github.com/fansforyou/fan-gopher/model"
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -50,8 +51,10 @@ func main() {
 
 	flag.Parse()
 
+	// Disable Leakless usage because Windows flags it as a virus
+	rodLauncherURL := launcher.New().Leakless(false).MustLaunch()
 	// Quiet the logger so that the only output is the eventual JSON
-	browser := rod.New().Logger(utils.LoggerQuiet)
+	browser := rod.New().ControlURL(rodLauncherURL).Logger(utils.LoggerQuiet)
 	if connectErr := browser.Connect(); connectErr != nil {
 		logger.Errorf("Failed to start browser while resolving post %d for creator '%s': %v", postID, creatorName, connectErr)
 		printError(connectErr)

--- a/test/integration/gopher/rod/rod_test.go
+++ b/test/integration/gopher/rod/rod_test.go
@@ -6,6 +6,7 @@ import (
 	gopherrod "github.com/fansforyou/fan-gopher/fans/rod"
 	"github.com/fansforyou/fan-gopher/model"
 	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/launcher"
 	"github.com/go-rod/rod/lib/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -15,7 +16,9 @@ var _ = Describe("Rod", Label("integration-test"), func() {
 	var gopher *gopherrod.RodGopher
 
 	BeforeEach(func() {
-		browser := rod.New().Logger(utils.LoggerQuiet)
+		// Disable Leakless usage because Windows flags it as a virus
+		rodLauncherURL := launcher.New().Leakless(false).MustLaunch()
+		browser := rod.New().ControlURL(rodLauncherURL).Logger(utils.LoggerQuiet)
 		connectErr := browser.Connect()
 		Expect(connectErr).To(BeNil(), "opening the browser should not have failed")
 		DeferCleanup(browser.MustClose)


### PR DESCRIPTION
Unless specified otherwise, the Rod library used by fan-gopher will use Leakless to auto-close the browse. Windows flags this as malware, which causes the application to not be able to run on Windows systems. This removes use of Leakless.